### PR TITLE
fix Smartisan T1 json parse error

### DIFF
--- a/WebViewJavascriptBridge/src/com/example/test/WVJBWebViewClient.java
+++ b/WebViewJavascriptBridge/src/com/example/test/WVJBWebViewClient.java
@@ -260,7 +260,7 @@ public class WVJBWebViewClient extends WebViewClient {
 						if (value != null && value.startsWith("\"")
 								&& value.endsWith("\"")) {
 							value = value.substring(1, value.length() - 1)
-									.replaceAll("\\\\", "");
+									.replaceAll("\\\\(?!u)", "");
 						}
 						callback.onReceiveValue(value);
 					}


### PR DESCRIPTION
在锤子T1（目前只发现这一款出现问题）上使用Bridge时，callback中拿到的JSON字符串如果含有汉字（会使用Unicode编码，\u0000），会被现有的`replaceAll("\\\\", "")`方法将编码格式破坏（**变成u0000**）导致不能正确解析。修改后的正则会**保留'u'前面的'\'**，确保编码格式正确，已测试过。
